### PR TITLE
feat: modernize UI — single DRR view, responsive layout, ragdoll face

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "docker-compose",
+      "runtimeExecutable": "docker",
+      "runtimeArgs": ["compose", "up", "--build"],
+      "port": 3000
+    }
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development Commands
+
+### Docker (recommended)
+```bash
+docker compose up --build   # Start both frontend and backend
+docker compose down         # Stop all services
+```
+
+### Backend (FastAPI)
+```bash
+cd backend
+pip install -r requirements.txt
+uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+```
+
+### Frontend (React + Vite)
+```bash
+cd frontend
+npm install
+npm run dev       # Dev server on port 3000
+npm run build     # Production build
+npm run preview   # Serve production build
+```
+
+## Architecture
+
+This project is a 2D/3D image registration tool being modernized from a legacy PySide2 desktop app into a web application. The work is currently in **Phase 1**: frontend/backend separation with a stub API.
+
+### Current Web Architecture
+
+**Frontend** (`frontend/src/App.jsx`) — React + Three.js
+- Single-page app with a 6-DOF pose control panel (Tx, Ty, Tz in mm; Rx, Ry, Rz in degrees)
+- Real-time 3D frame widget (`FrameIllustration`) showing CT volume, patient model, and AP camera frustum using `@react-three/fiber`
+- Rotation convention: R = Rz · Ry · Rx
+- "Generate DRR" button posts to the backend and displays 4 returned DRR views
+- No external state manager; all state lives in `App.jsx` via React hooks
+
+**Backend** (`backend/app/main.py`) — FastAPI
+- `POST /api/drr/generate` — accepts pose parameters, currently returns 4 placeholder 512×512 PNGs (PIL-generated) as base64 data URIs
+- `GET /health` — health check
+- Phase 1 stub: real DRR computation (raytracing) is not yet wired in
+
+**API contract:**
+```json
+// Request
+{ "tx": 0, "ty": 0, "tz": 0, "rx": 0, "ry": 0, "rz": 0 }
+
+// Response
+{ "drrs": ["data:image/png;base64,...", ...] }  // 4 views
+```
+
+### Legacy Desktop Code (root-level `.py` files)
+
+The real DRR computation logic lives in root-level Python files — not yet integrated into the backend:
+- `raybox.py` — CPU/GPU ray tracing engine (uses pycuda optionally); `kernels.cu` holds the CUDA kernels
+- `camera.py` / `camera_set.py` — camera projection model with intrinsics (K) and extrinsics
+- `drr_registration.py` — scipy optimization loop comparing synthetic DRRs to X-ray images
+- `compute_error.py` — image similarity metrics, masking, DLT reconstruction
+- `metrics.py` — NCC and other registration metrics
+- `main_window.py` — legacy PySide2 GUI (reference for porting logic)
+- `test_funs.py` — procedural integration tests (not pytest); expects test data in `Test_Data/Sawbones_L2L3/`
+
+### Modernization Roadmap
+Phase 1 (current): UI + stub API + Docker
+Phase 2 (next): Wire real DRR computation from legacy code into the FastAPI backend

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,3 +67,36 @@ The real DRR computation logic lives in root-level Python files — not yet inte
 ### Modernization Roadmap
 Phase 1 (current): UI + stub API + Docker
 Phase 2 (next): Wire real DRR computation from legacy code into the FastAPI backend
+
+## Git Worktree Gotcha
+
+When Claude Code works inside a **git worktree** (`.claude/worktrees/<name>`), the `.git` entry is a *file* (not a folder) containing a pointer like:
+
+```
+gitdir: /path/to/repo.git/worktrees/<name>
+```
+
+Git can resolve the metadata from this pointer, but it cannot infer the working-tree path from the Bash tool's CWD (which is outside the worktree). Plain `git` commands will fail with:
+
+```
+fatal: this operation must be run in a work tree
+```
+
+**Fix:** always prefix git commands with both environment variables:
+
+```bash
+GIT_DIR=/Users/reda/Projects/2D3DAutoReg.git/worktrees/nostalgic-poitras \
+GIT_WORK_TREE=/Users/reda/Projects/2D3DAutoReg.git/main/.claude/worktrees/nostalgic-poitras \
+git <command>
+```
+
+Or export them once at the top of a multi-command script:
+
+```bash
+export GIT_DIR=...  GIT_WORK_TREE=...
+git status
+git add ...
+git commit ...
+```
+
+This is required for the entire duration of a worktree session because the Bash tool's working directory never changes to the worktree path automatically.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -61,9 +61,6 @@ def generate_drr(payload: DrrRequest) -> dict:
     return {
         "pose": payload.pose.model_dump(),
         "drrs": [
-            {"view": 1, "image": drr_data_url},
-            {"view": 2, "image": drr_data_url},
-            {"view": 3, "image": drr_data_url},
-            {"view": 4, "image": drr_data_url},
+            {"view": "Main View", "image": drr_data_url},
         ],
     }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -29,13 +29,13 @@ const AXIS_COLORS = {
   z: '#2f7de1',
 }
 
-const PLACEHOLDER_VIEWS = [{ view: 1 }, { view: 2 }, { view: 3 }, { view: 4 }]
+const PLACEHOLDER_VIEWS = [{ view: 'Main View' }]
 
 const MM_TO_SCENE = 0.115
 const FRAME_CAMERA_DEFAULT = {
-  position: [7.2, 2.4, 7.1],
-  target: [0, -0.1, -0.2],
-  fov: 34,
+  position: [22, 5, -6.9],
+  target: [0, 0.46, -6.9],
+  fov: 46,
 }
 
 const toRad = (deg) => (deg * Math.PI) / 180
@@ -154,6 +154,20 @@ function PatientModel({ origin }) {
       <mesh position={[0, 1.95, 0]}>
         <sphereGeometry args={[0.46, 24, 24]} />
         <meshStandardMaterial color="#1f49e0" metalness={0.08} roughness={0.3} />
+      </mesh>
+
+      {/* Face features on +Z side to distinguish front from back */}
+      <mesh position={[-0.16, 2.08, 0.40]}>
+        <sphereGeometry args={[0.08, 12, 12]} />
+        <meshStandardMaterial color="#ffffff" emissive="#ffffff" emissiveIntensity={0.6} />
+      </mesh>
+      <mesh position={[0.16, 2.08, 0.40]}>
+        <sphereGeometry args={[0.08, 12, 12]} />
+        <meshStandardMaterial color="#ffffff" emissive="#ffffff" emissiveIntensity={0.6} />
+      </mesh>
+      <mesh position={[0, 1.82, 0.40]}>
+        <boxGeometry args={[0.22, 0.055, 0.05]} />
+        <meshStandardMaterial color="#ffffff" emissive="#ffffff" emissiveIntensity={0.6} />
       </mesh>
 
       <mesh position={[0, 0.78, 0]}>
@@ -410,8 +424,7 @@ function FrameIllustration({ pose }) {
 }
 
 function PoseAxisCard({ param, value, onChange }) {
-  const quickStep = param.group === 'translation' ? 5 : 2
-  const coarseStep = param.group === 'translation' ? 20 : 10
+  const step = param.group === 'translation' ? 5 : 2
 
   const handleNumber = (event) => {
     const next = Number(event.target.value)
@@ -424,79 +437,46 @@ function PoseAxisCard({ param, value, onChange }) {
   }
 
   return (
-    <article className={`pose-axis-card ${param.group}`}>
-      <header className="pose-axis-card-head">
-        <div className="pose-axis-meta">
-          <span className={`pose-axis-dot ${param.group}`} />
-          <span className="pose-axis-label">{param.label}</span>
-        </div>
-        <span className="pose-axis-unit">{param.unit}</span>
-      </header>
-
-      <div className="pose-axis-value-wrap">
-        <button
-          type="button"
-          className="axis-step-btn"
-          onClick={() => applyDelta(-quickStep)}
-          aria-label={`Decrease ${param.label} by ${quickStep}`}
-        >
-          -{quickStep}
-        </button>
-
-        <input
-          className="pose-axis-value"
-          type="number"
-          min={param.min}
-          max={param.max}
-          step={param.step}
-          value={value}
-          onChange={handleNumber}
-          aria-label={`${param.label} value`}
-        />
-
-        <button
-          type="button"
-          className="axis-step-btn"
-          onClick={() => applyDelta(quickStep)}
-          aria-label={`Increase ${param.label} by ${quickStep}`}
-        >
-          +{quickStep}
-        </button>
-      </div>
-
-      <div className="pose-axis-actions">
-        <button
-          type="button"
-          className="axis-mini-btn subtle"
-          onClick={() => applyDelta(-coarseStep)}
-          aria-label={`Decrease ${param.label} by ${coarseStep}`}
-        >
-          -{coarseStep}
-        </button>
-        <button type="button" className="axis-zero-btn" onClick={() => onChange(param.key, 0)} aria-label={`Zero ${param.label}`}>
-          0
-        </button>
-        <button
-          type="button"
-          className="axis-mini-btn"
-          onClick={() => applyDelta(coarseStep)}
-          aria-label={`Increase ${param.label} by ${coarseStep}`}
-        >
-          +{coarseStep}
-        </button>
+    <div className={`pose-row ${param.group}`}>
+      <div className="pose-row-label">
+        <span className={`pose-axis-dot ${param.group}`} />
+        <span className="pose-axis-label">{param.label}</span>
       </div>
 
       <input
-        className={`axis-range card ${param.group}`}
+        className={`axis-range ${param.group}`}
         type="range"
         min={param.min}
         max={param.max}
         step={param.step}
         value={value}
-        onChange={(event) => onChange(param.key, Number(event.target.value))}
+        onChange={(e) => onChange(param.key, Number(e.target.value))}
         aria-label={`${param.label} slider`}
       />
-    </article>
+
+      <button type="button" className="axis-step-btn" onClick={() => applyDelta(-step)} aria-label={`-${step}`}>
+        −
+      </button>
+
+      <input
+        className="pose-axis-value"
+        type="number"
+        min={param.min}
+        max={param.max}
+        step={param.step}
+        value={value}
+        onChange={handleNumber}
+        aria-label={`${param.label} value`}
+      />
+
+      <button type="button" className="axis-step-btn" onClick={() => applyDelta(step)} aria-label={`+${step}`}>
+        +
+      </button>
+
+      <button type="button" className="axis-zero-btn" onClick={() => onChange(param.key, 0)} aria-label={`Zero ${param.label}`}>
+        0
+      </button>
+    </div>
   )
 }
 
@@ -521,35 +501,25 @@ function PoseControlsPanel({
         </button>
       </header>
 
-      <div className="pose-sections">
-        <section className="axis-group">
-          <header className="axis-group-head">
-            <h3>Translation (mm)</h3>
-            <button type="button" className="ghost-btn tiny" onClick={() => onResetGroup('translation')}>
-              Zero T
-            </button>
-          </header>
-          <div className="axis-card-grid">
-            {translationControls.map((param) => (
-              <PoseAxisCard key={param.key} param={param} value={pose[param.key]} onChange={onChangePose} />
-            ))}
-          </div>
-        </section>
+      <section className="axis-group">
+        <header className="axis-group-head">
+          <h3>Translation (mm)</h3>
+          <button type="button" className="ghost-btn tiny" onClick={() => onResetGroup('translation')}>Zero T</button>
+        </header>
+        {translationControls.map((param) => (
+          <PoseAxisCard key={param.key} param={param} value={pose[param.key]} onChange={onChangePose} />
+        ))}
+      </section>
 
-        <section className="axis-group">
-          <header className="axis-group-head">
-            <h3>Rotation (deg)</h3>
-            <button type="button" className="ghost-btn tiny" onClick={() => onResetGroup('rotation')}>
-              Zero R
-            </button>
-          </header>
-          <div className="axis-card-grid">
-            {rotationControls.map((param) => (
-              <PoseAxisCard key={param.key} param={param} value={pose[param.key]} onChange={onChangePose} />
-            ))}
-          </div>
-        </section>
-      </div>
+      <section className="axis-group">
+        <header className="axis-group-head">
+          <h3>Rotation (deg)</h3>
+          <button type="button" className="ghost-btn tiny" onClick={() => onResetGroup('rotation')}>Zero R</button>
+        </header>
+        {rotationControls.map((param) => (
+          <PoseAxisCard key={param.key} param={param} value={pose[param.key]} onChange={onChangePose} />
+        ))}
+      </section>
 
       <p className="pose-convention">R = Rz * Ry * Rx, p_out = R*p_in + t.</p>
     </section>
@@ -637,16 +607,16 @@ export default function App() {
         </div>
       </header>
 
-      {error ? <p className="error-text">{error}</p> : null}
-
-      <section className="workspace-layout">
+      <div className="workspace-wrap">
+        {error ? <p className="error-text">{error}</p> : null}
+        <section className="workspace-layout">
         <section className="results-panel">
           <header className="results-head">
             <div>
               <p className="eyebrow">Output</p>
               <h2>DRR Views</h2>
             </div>
-            <p className="results-note">AP camera returns 4 projections from the backend stub.</p>
+            <p className="results-note">Backend stub projection.</p>
           </header>
 
           <section className="results-grid">
@@ -654,7 +624,7 @@ export default function App() {
               <figure key={drr.view} className="drr-tile">
                 <div className="drr-viewport">
                   {drr.image ? (
-                    <img src={drr.image} alt={`DRR view ${drr.view}`} />
+                    <img src={drr.image} alt={drr.view} />
                   ) : (
                     <div className={`drr-empty ${isLoading ? 'loading' : ''}`}>
                       {isLoading ? 'Rendering projection...' : 'Generate to load image'}
@@ -663,7 +633,7 @@ export default function App() {
                   {isLoading && drr.image ? <div className="tile-overlay">Updating...</div> : null}
                 </div>
                 <figcaption>
-                  <span>View {drr.view}</span>
+                  <span>{drr.view}</span>
                   <span className="view-tag">{drr.image ? 'Ready' : 'Pending'}</span>
                 </figcaption>
               </figure>
@@ -671,16 +641,15 @@ export default function App() {
           </section>
         </section>
 
-        <aside className="right-rail">
-          <FrameIllustration pose={pose} />
-          <PoseControlsPanel
-            pose={pose}
-            onChangePose={updatePose}
-            onResetGroup={resetGroup}
-            onResetPose={resetPose}
-          />
-        </aside>
+        <FrameIllustration pose={pose} />
+        <PoseControlsPanel
+          pose={pose}
+          onChangePose={updatePose}
+          onResetGroup={resetGroup}
+          onResetPose={resetPose}
+        />
       </section>
+      </div>
     </main>
   )
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -11,18 +11,28 @@
   box-sizing: border-box;
 }
 
+html,
 body {
   margin: 0;
+  height: 100%;
 }
 
 .app-shell {
   width: min(1760px, 100%);
   margin: 0 auto;
-  min-height: 100vh;
+  height: 100vh;
   display: grid;
-  grid-template-rows: auto auto minmax(0, 1fr);
+  grid-template-rows: auto minmax(0, 1fr);
   gap: 0.72rem;
   padding: 0.85rem;
+  overflow: hidden;
+}
+
+.workspace-wrap {
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.72rem;
 }
 
 .eyebrow {
@@ -167,13 +177,23 @@ body {
   font-size: 0.82rem;
 }
 
+/* ── Workspace: 2-col top row + full-width bottom row ─────── */
+
 .workspace-layout {
   min-height: 0;
+  flex: 1;
   display: grid;
-  grid-template-columns: minmax(0, 1.64fr) minmax(420px, 1fr);
+  grid-template-columns: 4fr 1fr;
+  grid-template-rows: minmax(0, 1fr) auto;
   gap: 0.76rem;
-  align-items: stretch;
 }
+
+/* Pose panel spans both columns in row 2 */
+.pose-panel {
+  grid-column: 1 / -1;
+}
+
+/* ── DRR Results panel ────────────────────────────────────── */
 
 .results-panel {
   background: linear-gradient(180deg, #ffffff 0%, #f9fcff 100%);
@@ -202,17 +222,14 @@ body {
 
 .results-note {
   margin: 0;
-  max-width: 24rem;
   color: #5b7390;
-  font-size: 0.82rem;
+  font-size: 0.78rem;
   text-align: right;
 }
 
 .results-grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  grid-template-rows: repeat(2, minmax(0, 1fr));
-  gap: 0.52rem;
+  grid-template-rows: minmax(0, 1fr);
   min-height: 0;
 }
 
@@ -294,18 +311,13 @@ body {
   padding: 0.1rem 0.38rem;
 }
 
-.right-rail {
-  min-height: 0;
-  display: grid;
-  grid-template-rows: minmax(300px, 0.8fr) minmax(0, 1.2fr);
-  gap: 0.62rem;
-}
+/* ── Frame sketch panel ───────────────────────────────────── */
 
 .frame-panel {
   background: #f7fafd;
   border: 1px solid #d3dfeb;
   border-radius: 12px;
-  padding: 0.52rem;
+  padding: 0.36rem;
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
   gap: 0.34rem;
@@ -327,7 +339,7 @@ body {
 .panel-title-row h2 {
   margin: 0;
   font-family: "Space Grotesk", "Avenir Next", "Segoe UI", sans-serif;
-  font-size: 0.98rem;
+  font-size: 0.82rem;
 }
 
 .panel-heading p {
@@ -354,10 +366,8 @@ body {
 
 .frame-canvas-wrap {
   width: 100%;
-  height: auto;
+  height: 100%;
   min-height: 0;
-  aspect-ratio: 1 / 1;
-  max-height: 100%;
   border-radius: 10px;
   overflow: hidden;
   border: 1px solid #ccd9e8;
@@ -370,16 +380,27 @@ body {
   display: block;
 }
 
+/* ── Pose panel ───────────────────────────────────────────── */
+
 .pose-panel {
   background: linear-gradient(175deg, #ffffff 0%, #f7fbff 100%);
   border: 1px solid #cedbe9;
   border-radius: 14px;
   box-shadow: 0 8px 26px rgba(30, 62, 98, 0.08);
-  padding: 0.56rem;
+  padding: 0.36rem 0.72rem;
   display: grid;
-  grid-template-rows: auto minmax(0, 1fr) auto;
-  gap: 0.42rem;
-  min-height: 0;
+  grid-template-columns: 1fr 1fr;
+  column-gap: 1.4rem;
+  row-gap: 0;
+  align-items: start;
+}
+
+/* Header spans all columns */
+.pose-panel-head {
+  grid-column: 1 / -1;
+  padding-bottom: 0.2rem;
+  border-bottom: 1px solid #e8f0f8;
+  margin-bottom: 0.2rem;
 }
 
 .pose-panel-head {
@@ -395,91 +416,66 @@ body {
   font-size: 0.95rem;
 }
 
-.axis-range {
-  width: 100%;
-  margin: 0;
-}
-
-.axis-range.translation {
-  accent-color: #1f6fd0;
-}
-
-.axis-range.rotation {
-  accent-color: #2f9a5f;
-}
-
-.pose-sections {
-  min-height: 0;
-  display: grid;
-  gap: 0.42rem;
-  overflow: auto;
-  padding-right: 0.02rem;
-}
+/* Group: Translation / Rotation */
 
 .axis-group {
-  border: 1px solid #d4dfec;
-  border-radius: 10px;
-  background: #ffffff;
-  padding: 0.34rem;
-  display: grid;
-  gap: 0.28rem;
-  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.06rem;
 }
 
 .axis-group-head {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 0.4rem;
+  margin-bottom: 0.1rem;
 }
 
 .axis-group-head h3 {
   margin: 0;
-  font-size: 0.75rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: #4a6480;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
 }
 
-.axis-card-grid {
+/* Single pose row: [label] [slider] [-] [value] [+] [0] */
+
+.pose-row {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.3rem;
+  grid-template-columns: 48px 1fr 26px 52px 26px 26px;
+  align-items: center;
+  gap: 0.22rem;
+  padding: 0.1rem 0.28rem;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  transition: background 80ms;
 }
 
-.pose-axis-card {
-  border: 1px solid #d7e1ec;
-  border-radius: 9px;
-  padding: 0.3rem;
-  display: grid;
-  grid-template-rows: auto auto auto auto;
-  gap: 0.24rem;
-  min-width: 0;
+.pose-row:hover {
+  background: #f0f6ff;
+  border-color: #dce8f5;
 }
 
-.pose-axis-card.translation {
-  background: linear-gradient(180deg, #f8fbff 0%, #ffffff 100%);
+.pose-row.rotation:hover {
+  background: #f2faf5;
+  border-color: #d3ecdf;
 }
 
-.pose-axis-card.rotation {
-  background: linear-gradient(180deg, #f8fdf9 0%, #ffffff 100%);
-}
-
-.pose-axis-card-head {
+.pose-row-label {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 0.2rem;
-}
-
-.pose-axis-meta {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.16rem;
+  align-items: baseline;
+  gap: 0.22rem;
   min-width: 0;
 }
 
 .pose-axis-dot {
-  width: 8px;
-  height: 8px;
+  width: 7px;
+  height: 7px;
   border-radius: 999px;
+  flex-shrink: 0;
+  align-self: center;
 }
 
 .pose-axis-dot.translation {
@@ -493,87 +489,93 @@ body {
 }
 
 .pose-axis-label {
-  font-size: 0.72rem;
+  font-size: 0.78rem;
   font-weight: 760;
-  color: #20384f;
+  color: #1a3148;
 }
 
 .pose-axis-unit {
   font-size: 0.53rem;
   text-transform: uppercase;
-  color: #5f7893;
+  color: #7a92ab;
   letter-spacing: 0.04em;
+  display: none; /* hidden in row — shown in group header */
 }
 
-.pose-axis-value-wrap {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 0.18rem;
+.axis-range {
+  width: 100%;
+  margin: 0;
+  cursor: pointer;
+}
+
+.axis-range.translation {
+  accent-color: #1f6fd0;
+}
+
+.axis-range.rotation {
+  accent-color: #2f9a5f;
+}
+
+.axis-step-btn,
+.axis-zero-btn {
+  border: 1px solid #c8d5e5;
+  background: #f7fbff;
+  color: #2f4f6b;
+  font-size: 0.68rem;
+  font-weight: 700;
+  padding: 0.2rem 0;
+  border-radius: 6px;
+  cursor: pointer;
+  text-align: center;
+  transition: background 100ms;
+}
+
+.axis-step-btn:hover,
+.axis-zero-btn:hover {
+  background: #e4f0fc;
+}
+
+.axis-zero-btn {
+  color: #5f7893;
 }
 
 .pose-axis-value {
   border: 1px solid #c8d6e5;
-  border-radius: 7px;
-  padding: 0.18rem 0.16rem;
+  border-radius: 6px;
+  padding: 0.2rem 0.12rem;
   background: #fbfdff;
-  color: #203449;
+  color: #1a3148;
   font-weight: 640;
-  font-size: 0.67rem;
+  font-size: 0.75rem;
   text-align: center;
   width: 100%;
+  min-width: 0;
 }
 
-.pose-axis-actions {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.16rem;
-  justify-content: center;
-}
-
-.axis-mini-btn,
-.axis-zero-btn,
-.axis-step-btn {
-  border: 1px solid #c8d5e5;
-  background: #f7fbff;
-  color: #2f4f6b;
-  font-size: 0.59rem;
-  font-weight: 730;
-  padding: 0.16rem 0.32rem;
-  min-width: 28px;
-  border-radius: 7px;
-}
-
-.axis-mini-btn.subtle {
-  color: #58718d;
-}
-
-.axis-step-btn {
-  min-width: 34px;
-}
-
-.axis-range.card {
-  width: 100%;
-  margin: 0;
+.pose-axis-value:focus {
+  outline: 2px solid #1f6fd0;
+  outline-offset: 1px;
 }
 
 .pose-convention {
+  grid-column: 1 / -1;
   margin: 0;
-  font-size: 0.64rem;
-  color: #607992;
+  font-size: 0.63rem;
+  color: #7a92ab;
+  padding-top: 0.3rem;
+  border-top: 1px solid #e8f0f8;
 }
+
+/* ── Animations ───────────────────────────────────────────── */
 
 @keyframes shimmer {
-  from {
-    background-position: 130% 0;
-  }
-
-  to {
-    background-position: -90% 0;
-  }
+  from { background-position: 130% 0; }
+  to   { background-position: -90% 0; }
 }
 
-@media (max-width: 1280px) {
+/* ── Responsive ───────────────────────────────────────────── */
+
+@media (max-width: 900px) {
   .topbar-card {
     grid-template-columns: 1fr auto;
     grid-template-areas:
@@ -582,80 +584,22 @@ body {
     align-items: start;
   }
 
-  .topbar-head {
-    grid-area: head;
-  }
+  .topbar-head    { grid-area: head; }
+  .topbar-status  { grid-area: status; }
+  .topbar-actions { grid-area: actions; align-self: center; }
 
-  .topbar-status {
-    grid-area: status;
-  }
-
-  .topbar-actions {
-    grid-area: actions;
-    align-self: center;
-  }
-
+  /* Stack: DRR full-width, frame hidden or below, pose full-width */
   .workspace-layout {
     grid-template-columns: 1fr;
-    grid-template-rows: minmax(360px, 55vh) minmax(0, 1fr);
+    grid-template-rows: minmax(0, 1fr) auto auto;
   }
 
-  .right-rail {
-    grid-template-columns: minmax(310px, 0.96fr) minmax(340px, 1.04fr);
-    grid-template-rows: none;
-    align-items: stretch;
+  .pose-panel {
+    grid-template-columns: 1fr;  /* stack groups vertically on small screens */
   }
 
-  .results-note {
-    max-width: 16rem;
-  }
-}
-
-@media (max-width: 980px) {
-  .app-shell {
-    min-height: unset;
-  }
-
-  .topbar-card {
-    grid-template-columns: 1fr;
-    grid-template-areas:
-      "head"
-      "status"
-      "actions";
-  }
-
-  .topbar-actions {
-    width: 100%;
-    justify-content: flex-start;
-    flex-wrap: wrap;
-  }
-
-  .workspace-layout {
-    grid-template-rows: minmax(340px, 50vh) minmax(0, 1fr);
-  }
-
-  .results-head {
-    flex-direction: column;
-    align-items: start;
-  }
-
-  .results-note {
-    text-align: left;
-    max-width: none;
-  }
-
-  .right-rail {
-    grid-template-columns: 1fr;
-    grid-template-rows: minmax(320px, 46vh) minmax(0, 1fr);
-  }
-
-  .axis-card-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-
-  .pose-sections {
-    overflow: visible;
-  }
+  .results-note { max-width: none; }
+  .results-head { flex-direction: column; align-items: start; }
 }
 
 @media (max-width: 760px) {
@@ -664,22 +608,15 @@ body {
     gap: 0.62rem;
   }
 
-  .results-grid {
-    grid-template-columns: 1fr;
-    grid-template-rows: none;
-  }
-
-  .drr-tile {
-    min-height: 220px;
-  }
+  .drr-tile { min-height: 220px; }
 
   .frame-canvas-wrap {
     max-width: 520px;
     justify-self: center;
   }
 
-  .axis-card-grid {
-    grid-template-columns: 1fr;
-    gap: 0.34rem;
+  .pose-row {
+    grid-template-columns: 44px 1fr 24px 48px 24px 24px;
+    gap: 0.2rem;
   }
 }


### PR DESCRIPTION
## Summary

- **Single DRR view**: Reduced from 4 placeholder views to 1 named "Main View"; backend updated to match
- **Responsive layout**: App fills 100vh with no dead space — DRR panel (80%) + frame sketch (20%) on row 1, compact full-width pose controls on row 2
- **Ragdoll face**: Added eyes and mouth to the patient head mesh so front vs back is visually distinguishable
- **Improved pose controls**: `PoseAxisCard` refactored to a compact horizontal row (label | slider | − | value | + | 0); Translation and Rotation groups rendered side-by-side
- **Frame sketch centering**: Removed `aspect-ratio` constraint so the canvas fills its panel height instead of sitting at the top
- **Better default camera**: Frame sketch opens with a side-on view that shows both the patient and AP camera frustum
- **Project scaffolding**: Added `CLAUDE.md` guide and `.claude/launch.json` for docker-compose dev server

## Test plan

- [ ] `docker compose up --build` — both containers start cleanly
- [ ] App fills the full browser window at any size; no empty space at the bottom
- [ ] Resizing the browser redistributes space correctly between DRR, frame sketch, and pose controls
- [ ] Frame sketch canvas is vertically centered in its panel
- [ ] Ragdoll head shows eyes and mouth on the front face
- [ ] "Generate DRR" returns a single "Main View" image
- [ ] Pose sliders (Tx/Ty/Tz/Rx/Ry/Rz) update the 3D frame sketch in real time
- [ ] Reset (0) buttons zero out each axis independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)