### PR TITLE
Replace venv with uv for Python dependency management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ export VITE_API_BASE_URL := http://localhost:$(BACKEND_PORT)
 # ── Phony targets ───────────────────────────────────────────────────
 
 .PHONY: install install-backend install-frontend \
-        dev backend frontend docker clean check-data help
+        dev backend frontend docker clean check-data check-uv help
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*##' $(MAKEFILE_LIST) | \
@@ -44,11 +44,11 @@ help: ## Show this help
 
 install: install-backend install-frontend ## Install all dependencies
 
-install-backend: $(VENV_DIR)/bin/activate ## Install backend (Python venv)
-$(VENV_DIR)/bin/activate:
-	python3 -m venv $(VENV_DIR)
-	$(PIP) install --upgrade pip
-	$(PIP) install -r $(BACKEND_DIR)/requirements.txt
+install-backend: check-uv ## Install backend with uv
+	cd $(BACKEND_DIR) && uv sync
+
+check-uv: ## Check that uv is installed
+	@command -v uv >/dev/null 2>&1 || { echo "Error: uv is not installed. Install from https://docs.astral.sh/uv/getting-started/"; exit 1; }
 
 install-frontend: $(FRONTEND_DIR)/node_modules ## Install frontend (npm)
 $(FRONTEND_DIR)/node_modules: $(FRONTEND_DIR)/package.json


### PR DESCRIPTION
## Summary
This PR migrates the backend Python dependency management from `venv` to `uv`, a faster and more modern Python package manager.

## Key Changes
- Replaced manual `venv` creation and pip installation with `uv sync` command
- Added `check-uv` target to verify `uv` is installed before attempting backend installation
- Made `install-backend` depend on `check-uv` to ensure the required tool is available
- Updated Makefile phony targets to include the new `check-uv` target
- Removed the file-based venv activation target in favor of a simpler command-based approach

## Implementation Details
- The `check-uv` target provides a helpful error message with installation instructions if `uv` is not found
- Backend installation now uses `uv sync` which reads from `pyproject.toml` or `uv.lock` (standard uv configuration)
- This change simplifies the installation process and improves performance compared to traditional venv + pip workflow

https://claude.ai/code/session_01Ybuy4Qm4w7Hm4PVg5J2uBj