### PR TITLE
Fix MPS backward pass and WebSocket stability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,13 +63,17 @@ check-data:
 dev: install check-data ## Run backend + frontend concurrently
 	@echo "Starting backend on :$(BACKEND_PORT) and frontend on :$(FRONTEND_PORT) …"
 	@trap 'kill 0' INT TERM; \
-	$(UVICORN) app.main:app --reload --host 0.0.0.0 --port $(BACKEND_PORT) \
+	$(UVICORN) app.main:app --reload \
+		--reload-dir $(BACKEND_DIR)/app \
+		--host 0.0.0.0 --port $(BACKEND_PORT) \
 		--app-dir $(BACKEND_DIR) & \
 	cd $(FRONTEND_DIR) && $(NPM) run dev & \
 	wait
 
 backend: install-backend check-data ## Run backend only
-	$(UVICORN) app.main:app --reload --host 0.0.0.0 --port $(BACKEND_PORT) \
+	$(UVICORN) app.main:app --reload \
+		--reload-dir $(BACKEND_DIR)/app \
+		--host 0.0.0.0 --port $(BACKEND_PORT) \
 		--app-dir $(BACKEND_DIR)
 
 frontend: install-frontend ## Run frontend only

--- a/backend/app/drr_engine.py
+++ b/backend/app/drr_engine.py
@@ -7,7 +7,12 @@ pipeline that auto-selects device (CUDA → MPS → CPU).
 import base64
 import logging
 import math
+import os
 from io import BytesIO
+
+# Enable CPU fallback for MPS ops missing backward (e.g. grid_sampler_3d_backward).
+# Must be set before importing torch.
+os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
 
 import nibabel as nib
 import numpy as np

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -129,7 +129,13 @@ async def websocket_endpoint(ws: WebSocket):
             msg_type = data.get("type")
 
             if msg_type == "registration_start":
-                await _handle_registration_start(ws, session, data)
+                try:
+                    await _handle_registration_start(ws, session, data)
+                except WebSocketDisconnect:
+                    raise  # let the outer handler deal with real disconnects
+                except Exception as exc:
+                    logger.exception("Session %s: registration handler error", session_id)
+                    await ws.send_json({"type": "error", "message": str(exc)})
             elif msg_type == "registration_cancel":
                 if session.runner and session.runner.is_running:
                     session.runner.cancel()

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -768,6 +768,7 @@ export default function App() {
 
       ws.onopen = () => {
         console.log('WebSocket connected')
+        setError('')
       }
 
       ws.onmessage = (event) => {
@@ -797,9 +798,14 @@ export default function App() {
 
       ws.onclose = () => {
         console.log('WebSocket disconnected')
-        wsRef.current = null
-        sessionIdRef.current = null
-        setSessionReady(false)
+        // Only clear refs if this is still the active WebSocket
+        // (React strict mode double-mount can cause a stale ws1.onclose
+        // to fire after ws2 has already been assigned to wsRef)
+        if (wsRef.current === ws) {
+          wsRef.current = null
+          sessionIdRef.current = null
+          setSessionReady(false)
+        }
         if (!disposed) {
           reconnectTimer = setTimeout(connect, 2000)
         }
@@ -1269,7 +1275,7 @@ export default function App() {
                   <button
                     type="button"
                     className="primary-btn mini"
-                    disabled={!targetImage}
+                    disabled={!targetImage || !sessionReady}
                     onClick={startRegistration}
                   >Start Registration</button>
                 )}


### PR DESCRIPTION
## Summary
- **MPS compatibility**: Enable `PYTORCH_ENABLE_MPS_FALLBACK=1` so `grid_sampler_3d_backward` falls back to CPU on Apple Silicon, fixing gradient-based registration (AdamW/SGD)
- **WebSocket race condition**: Fix React strict mode double-mount causing `wsRef.current` to be nullified by a stale WS `onclose`, resulting in "WebSocket not connected" errors
- **Registration error handling**: Wrap `_handle_registration_start` in try/except so backend errors send a JSON error message instead of crashing the WebSocket
- **UI guard**: Disable "Start Registration" button when session isn't ready
- **Dev reload scoping**: Restrict uvicorn `--reload` to `backend/app/` to avoid restarts on unrelated file changes

## Test plan
- [ ] Run `make dev` on macOS with Apple Silicon — backend starts without error
- [ ] Open app, generate DRR, upload target, run Scipy-Powell registration — completes successfully
- [ ] Run AdamW/SGD registration — `loss.backward()` succeeds via CPU fallback
- [ ] Open/close multiple browser tabs rapidly — no stale "WebSocket not connected" errors
- [ ] Trigger a registration error (e.g. without target) — error message shown, WS stays connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)